### PR TITLE
Added a function_exists check to stargazer_excerpt_length to allow child themes to extend/overwrite this function

### DIFF
--- a/inc/stargazer.php
+++ b/inc/stargazer.php
@@ -256,8 +256,11 @@ function stargazer_aside_infinity( $html ) {
  * @param  int     $length
  * @return int
  */
-function stargazer_excerpt_length( $length ) {
-	return 30;
+if ( ! function_exists( 'stargazer_excerpt_length' ) ) {
+
+	function stargazer_excerpt_length( $length ) {
+		return 30;
+	}
 }
 
 /**


### PR DESCRIPTION
Title says it all. Could more of Stargazer's functions follow the same practices?
