### PR TITLE
Modify ja.css for better Japanese readability

### DIFF
--- a/css/ja.css
+++ b/css/ja.css
@@ -10,7 +10,7 @@ textarea,
 .required,
 #site-description,
 #reply-title small { 
-	font-family: "ヒラギノ明朝 Pro W3", "Hiragino Mincho Pro W3", "HG明朝E", "HG Mincho E", "ＭＳ Ｐ明朝", "MS PMincho", serif;
+	font-family: 'Droid Serif', 'Lora', Georgia, "ヒラギノ明朝 Pro W3", "Hiragino Mincho Pro W3", "HG明朝E", "HG Mincho E", "ＭＳ Ｐ明朝", "MS PMincho", serif;
 	line-height: 1.7;
 }
 


### PR DESCRIPTION
For .font-primary, change below items for better readability.
- Changed Japanese fonts from gothic to mincho.
- Changed line-height.

While <code>"ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", Osaka, "メイリオ", Meiryo, "ＭＳ Ｐゴシック", "MS PGothic"</code> is a popular font-family set for Japanese websites, these are all gothic fonts, equivalent to sans-serif. So changed to mincho fonts, equivalent to serif fonts.

Japanese letters looks slightly bigger, compared to English letters of same font size. So larger line-height is usually specified.
